### PR TITLE
enh: make it work with latest esp-idf master

### DIFF
--- a/main/esp_zb_light.c
+++ b/main/esp_zb_light.c
@@ -78,7 +78,7 @@ static esp_err_t zb_attribute_handler(const esp_zb_zcl_set_attr_value_message_t 
              message->attribute.id, message->attribute.data.size);
     if (message->info.dst_endpoint == HA_ESP_LIGHT_ENDPOINT)
     {
-        if (message->attribute.id == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF)
+        if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF)
         {
             if (message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL)
             {

--- a/main/esp_zb_light.c
+++ b/main/esp_zb_light.c
@@ -1,4 +1,5 @@
 #include "nvs_flash.h"
+#include "esp_check.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -66,34 +67,45 @@ static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask)
     ESP_ERROR_CHECK(esp_zb_bdb_start_top_level_commissioning(mode_mask));
 }
 
-static esp_err_t attr_cb(const esp_zb_zcl_set_attr_value_message_t message)
+static esp_err_t zb_attribute_handler(const esp_zb_zcl_set_attr_value_message_t *message)
 {
     esp_err_t ret = ESP_OK;
     bool light_state = 0;
-    if (message.info.status == ESP_ZB_ZCL_STATUS_SUCCESS)
+    ESP_RETURN_ON_FALSE(message, ESP_FAIL, TAG, "Empty message");
+    ESP_RETURN_ON_FALSE(message->info.status == ESP_ZB_ZCL_STATUS_SUCCESS, ESP_ERR_INVALID_ARG, TAG, "Received message: error status(%d)",
+                        message->info.status);
+    ESP_LOGI(TAG, "Received message: endpoint(0x%x), cluster(0x%x), attribute(0x%x), data size(%d)", message->info.dst_endpoint, message->info.cluster,
+             message->attribute.id, message->attribute.data.size);
+    if (message->info.dst_endpoint == HA_ESP_LIGHT_ENDPOINT)
     {
-        ESP_LOGI(TAG, "Received message: endpoint(0x%x), cluster(0x%x), attribute(0x%x), data size(%d)", message.info.dst_endpoint,
-                 message.info.cluster, message.attribute, message.data.size);
-        if (message.info.dst_endpoint == HA_ESP_LIGHT_ENDPOINT)
+        if (message->attribute.id == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF)
         {
-            if (message.info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF)
+            if (message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL)
             {
-                if (message.attribute == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && message.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL)
-                {
-                    light_state = message.data.value ? *(bool *)message.data.value : light_state;
-                    gpio_set_level(GPIO_NUM_0, light_state);
-                    ESP_LOGI(TAG, "Light sets to %s", light_state ? "On" : "Off");
-                }
+                light_state = message->attribute.data.value ? *(bool *)message->attribute.data.value : light_state;
+                gpio_set_level(GPIO_NUM_0, light_state);
+                ESP_LOGI(TAG, "Light sets to %s", light_state ? "On" : "Off");
             }
         }
     }
-    else
+    return ret;
+}
+
+static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id, const void *message)
+{
+    esp_err_t ret = ESP_OK;
+    switch (callback_id)
     {
-        ESP_LOGE(TAG, "Received message: status(%d) error", message.info.status);
-        ret = ESP_ERR_INVALID_ARG;
+    case ESP_ZB_CORE_SET_ATTR_VALUE_CB_ID:
+        ret = zb_attribute_handler((esp_zb_zcl_set_attr_value_message_t *)message);
+        break;
+    default:
+        ESP_LOGW(TAG, "Receive Zigbee action(0x%x) callback", callback_id);
+        break;
     }
     return ret;
 }
+
 void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
 {
     uint32_t *p_sg_p = signal_struct->p_app_signal;
@@ -220,7 +232,7 @@ static void esp_zb_task(void *pvParameters)
 
     // ------------------------------ Register Device ------------------------------
     esp_zb_device_register(esp_zb_ep_list);
-    esp_zb_device_add_set_attr_value_cb(attr_cb);
+    esp_zb_core_action_handler_register(zb_action_handler);
     esp_zb_set_primary_network_channel_set(ESP_ZB_PRIMARY_CHANNEL_MASK);
 
     ESP_ERROR_CHECK(esp_zb_start(false));

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~0.6.0"
+  espressif/esp-zboss-lib: "~0.7.0"
   espressif/esp-zigbee-lib: "~0.9.0"
   espressif/led_strip: "~2.0.0"
 


### PR DESCRIPTION
# Why
It seems latest esp-idf changes are incompatible with this repo.
This PR aims at making it compatible.
Issue #1 seems related.

# Test on esp32-c6
- [x] compiles
- [x] end device is recognized by Home Assistant